### PR TITLE
Fix Task names that are misnumbered, etc.

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -36,7 +36,7 @@
         line: "install jffs2 /bin/true"
         state: present
         create: true
-    - name: 1.1.1.2 Ensure mounting of jffs2 filesystems is disabled
+    - name: 1.1.1.2 Ensure mounting of jffs2 filesystems is disabled - modprobe
       modprobe:
         name: jffs2
         state: absent

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -247,12 +247,12 @@
     1.1.9 Ensure nosuid option set on /var/tmp partition,
     1.1.10 Ensure noexec option set on /var/tmp partition
   block:
-    - name:  1.1.7 Ensure separate partition exists for /var/tmp
+    - name: 1.1.7 Ensure separate partition exists for /var/tmp
       assert:
         that: ansible_mounts | byattr('mount', '/var/tmp') | list | length > 0
         fail_msg: "/var/tmp is NOT a separate partition"
         success_msg: "/var/tmp is a separate partition"
-    - name:  1.1.8 Ensure nodev option set on /var/tmp partition,
+    - name: 1.1.8 Ensure nodev option set on /var/tmp partition,
         1.1.9 Ensure nosuid option set on /var/tmp partition,
         1.1.10 Ensure noexec option set on /var/tmp partition
       mount:
@@ -314,7 +314,7 @@
 - name: 1.1.13 Ensure separate partition exists for /home,
     1.1.14 Ensure nodev option set on /home partition
   block:
-    - name:  1.1.13 Ensure separate partition exists for /home
+    - name: 1.1.13 Ensure separate partition exists for /home
       assert:
         that: ansible_mounts | byattr('mount', '/home') | list | length > 0
         fail_msg: "/home is NOT a separate partition"
@@ -629,9 +629,9 @@
         name: ["nullmailer", "aide-common", "aide"]
         state: present
         install_recommends: false
-    - name: Configure AIDE as appropriate for your environment - aideinit
+    - name: 1.4.1 Configure AIDE as appropriate for your environment - aideinit
       command: aideinit
-    - name: Configure AIDE as appropriate for your environment - aideinit db
+    - name: 1.4.1 Configure AIDE as appropriate for your environment - aideinit db
       shell: |
         mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db
   tags:

--- a/tasks/section_2_Services.yaml
+++ b/tasks/section_2_Services.yaml
@@ -48,11 +48,11 @@
 # systemd-timesyncd should be stopped and masked
 - name: 2.2.1.1 Ensure time synchronization is in use
   block:
-    - name: 2.2.1.3 Ensure time synchronization is in use - service install
+    - name: 2.2.1.1 Ensure time synchronization is in use - service install
       apt:
         name: ["chrony"]
         state: present
-    - name: 2.2.1.3 Ensure time synchronization is in use - service start
+    - name: 2.2.1.1 Ensure time synchronization is in use - service start
       service:
         name: "chrony"
         state: started
@@ -208,7 +208,7 @@
         state: stopped
         enabled : no
       ignore_errors: true
-    - name: 2.2.7 Ensure NFS is not enabled - rpcbind
+    - name: 2.2.7 Ensure RPC is not enabled - rpcbind
       service:
         name: rpcbind
         state: stopped

--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -59,9 +59,9 @@
     - scored
 # 3.2.2 Ensure IP forwarding is disabled
 # Setting the flags to 0 ensures that a system with multiple interfaces (for example, a hard proxy), will never be able to forward packets, and therefore, never serve as a router.
-- name: 3.2.2 Ensure IP forwarding is disabled"
+- name: 3.2.2 Ensure IP forwarding is disabled
   block:
-    - name: 3.2.2 Ensure IP forwarding is disabled - ipv4"
+    - name: 3.2.2 Ensure IP forwarding is disabled - ipv4
       sysctl:
         name: net.ipv4.ip_forward
         value: "0"
@@ -70,7 +70,7 @@
         reload: true
       notify:
         - ipv4 flush route
-    - name: 3.2.2 Ensure IP forwarding is disabled - ipv6"
+    - name: 3.2.2 Ensure IP forwarding is disabled - ipv6
       sysctl:
         name: net.ipv6.conf.all.forwarding
         value: "0"
@@ -80,11 +80,11 @@
       notify:
         - ipv4 flush route
       when: IPv6_is_enabled
-    - name: 3.2.2 Ensure IP forwarding is disabled - ipv4 fix"
+    - name: 3.2.2 Ensure IP forwarding is disabled - ipv4 fix
       shell: grep -Els "^\s*net\.ipv4\.ip_forward\s*=\s*1" /etc/sysctl.conf /etc/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /run/sysctl.d/*.conf | while read filename; do sed -ri "s/^\s*(net\.ipv4\.ip_forward\s*)(=)(\s*\S+\b).*$/#*REMOVED* \1/" $filename; echo $filename ; done
       register: output_3_2_2
       changed_when: output_3_2_2.stdout_lines | length > 0
-    - name: 3.2.2 Ensure IP forwarding is disabled - ipv6 fix"
+    - name: 3.2.2 Ensure IP forwarding is disabled - ipv6 fix
       shell: grep -Els "^\s*net\.ipv6\.conf\.all\.forwarding\s*=\s*1" /etc/sysctl.conf /etc/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /run/sysctl.d/*.conf | while read filename; do sed -ri "s/^\s*(net\.ipv6\.conf\.all\.forwarding\s*)(=)(\s*\S+\b).*$/# *REMOVED* \1/" $filename; echo $filename ; done
       register: output_3_2_2_v6
       changed_when: output_3_2_2_v6.stdout_lines | length > 0
@@ -555,7 +555,7 @@
 # 3.5.2.5 Ensure firewall rules exist for all open ports
 # Without a firewall rule configured for open ports default firewall policy will drop all
 # packets to these ports.
-- name: 3.5.2.5 Ensure firewall rules exist for all open ports - enable {{ item.desc }}"
+- name: 3.5.2.5 Ensure firewall rules exist for all open ports - enable "{{ item.desc }}"
   ufw:
     rule: "{{ item.rule }}"
     port: "{{ item.port }}"
@@ -671,7 +671,7 @@
     #   shell: nft chain inet filter INPUT { tcp dport ssh accept \;}
     # - name: 3.5.3.6 Ensure default deny firewall policy - enable ping
     #   shell: nft chain inet filter INPUT { ip protocol icmp accept \;}
-    - name: 3.5.3.6 Ensure default deny firewall policy - enable {{ item.desc }}
+    - name: 3.5.3.6 Ensure default deny firewall policy - enable "{{ item.desc }}"
       shell: nft add rule inet filter INPUT "{{ item.rule }}"
       with_items: "{{ list_of_rules_to_allow }}"
     - name: 3.5.3.6 Ensure default deny firewall policy - input

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -894,7 +894,7 @@
 # via sudo, whereas su can only record that a user executed the su program.
 - name: 5.6 Ensure access to the su command is restricted
   block:
-    - name: 5.6 Ensure access to the su command is restricted -groupadd
+    - name: 5.6 Ensure access to the su command is restricted - groupadd
       command: groupadd sugroup
     - name: 5.6 Ensure access to the su command is restricted - change
       lineinfile:

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -366,7 +366,7 @@
         grep '^\+:' /etc/group && true || true
       changed_when: output_6_2_5.stdout | trim | length > 0
       register: output_6_2_5
-    - name: 6.2.4 Ensure no legacy "+" entries exist in /etc/group - print output
+    - name: 6.2.5 Ensure no legacy "+" entries exist in /etc/group - print output
       debug:
         msg: "{{ output_6_2_5.stdout_lines }}"
   tags:
@@ -555,7 +555,7 @@
       script: 6_2_14.sh
       changed_when: output_6_2_14.stdout | trim | length > 0
       register: output_6_2_14
-    - name: 6.2.11 Ensure no users have .rhosts files - print output
+    - name: 6.2.14 Ensure no users have .rhosts files - print output
       debug:
         msg: "{{ output_6_2_14.stdout_lines }}"
   tags:


### PR DESCRIPTION
Fix Task names that are incorrectly numbered, have incomplete formatting (e.g. `"` missing), or have incorrect descriptions.