### PR TITLE
Fix Usage of Registered Variable for 3.1.2

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -30,7 +30,7 @@
         msg: "{{ output_3_1_2 }}"
     - name: 3.1.2 Ensure wireless interfaces are disabled - fix
       script: 3_1_2_disable.sh
-      when: output_3_1_2.stdout is search("is enabled")
+      when: output_3_1_2 is search("is enabled")
   tags:
     - section3
     - level_1_server

--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -23,8 +23,11 @@
   block:
     - name: 3.1.2 Ensure wireless interfaces are disabled - verify
       script: 3_1_2.sh
-      changed_when: output_3_1_2.stdout is search("is enabled")
+      changed_when: output_3_1_2 is search("is enabled")
       register: output_3_1_2
+    - name: 3.1.2 Ensure wireless interfaces are disabled - print output
+      debug:
+        msg: "{{ output_3_1_2 }}"
     - name: 3.1.2 Ensure wireless interfaces are disabled - fix
       script: 3_1_2_disable.sh
       when: output_3_1_2.stdout is search("is enabled")


### PR DESCRIPTION
Previously, playbook was attempting to use `output_3_1_2.stdout` but attribute `stdout` didn't exist which would cause the following error:

```
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'output_3_1_2.stdout is search(\"is enabled\")' failed. The error was: error while evaluating conditional (output_3_1_2.stdout is search(\"is enabled\")): 'dict object' has no attribute 'stdout'"}
```

This update removes the attempted usage of the attribute `stdout`.

Also, a debug has been added to show contents of `output_3_1_2` which displays a variation of the following (depending on your environment of course):

```
TASK [CIS-Debian10-Ansible : 3.1.2 Ensure wireless interfaces are disabled - print output] ********************************
ok: [localhost] => {
    "msg": {
        "changed": false,
        "failed": false
    }
}
```