### PR TITLE
Change groupadd Command to Ansible Module for 5.6

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -895,7 +895,9 @@
 - name: 5.6 Ensure access to the su command is restricted
   block:
     - name: 5.6 Ensure access to the su command is restricted -groupadd
-      command: groupadd sugroup
+      group:
+        name: sugroup
+        state: present
     - name: 5.6 Ensure access to the su command is restricted - change
       lineinfile:
         state: present


### PR DESCRIPTION
With current command `groupadd sugroup`, rerun will fail because the group already exists.

This changes 5.6 to use the Ansible `group` module which won't fail on reruns.