### PR TITLE
Add "list" to end of a few "with_items" filter

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -352,7 +352,7 @@
     fstype: "{{ item.fstype }}"
     src: "{{ item.device }}"
     opts: "{{ item.options.split(',') | union(['nodev']) | join(',') }}"
-  with_items: "{{ all_mounts.stdout | default('{}') | from_json |  byattr('mount', '/dev/shm') }}"
+  with_items: "{{ all_mounts.stdout | default('{}') | from_json | byattr('mount', '/dev/shm') | list }}"
   tags:
     - section1
     - level_1_server
@@ -377,7 +377,7 @@
     fstype: "{{ item.fstype }}"
     src: "{{ item.device }}"
     opts: "{{ item.options.split(',') | union(['nosuid']) | join(',') }}"
-  with_items: "{{ all_mounts.stdout | default('{}') | from_json |  byattr('mount', '/dev/shm') }}"
+  with_items: "{{ all_mounts.stdout | default('{}') | from_json | byattr('mount', '/dev/shm') | list }}"
   tags:
     - section1
     - level_1_server
@@ -402,7 +402,7 @@
     fstype: "{{ item.fstype }}"
     src: "{{ item.device }}"
     opts: "{{ item.options.split(',') | union(['noexec']) | join(',') }}"
-  with_items: "{{ all_mounts.stdout | default('{}') | from_json |  byattr('mount', '/dev/shm') }}"
+  with_items: "{{ all_mounts.stdout | default('{}') | from_json | byattr('mount', '/dev/shm') | list }}"
   tags:
     - section1
     - level_1_server


### PR DESCRIPTION
Error was not received when running Ansible Playbook locally on a host but when running remotely would receive the following:

```
TASK [CIS-Debian10-Ansible : 1.1.15 Ensure nodev option set on /dev/shm partition] *****************************************************************************************************************************************************************************
fatal: [a.b.c.d]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'mount'\n\nThe error appears to be in '/path/CIS-Debian10-Ansible/tasks/section_1_Initial_Setup.yaml': line 352, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n    - scored\n- name: 1.1.15 Ensure nodev option set on /dev/shm partition\n  ^ here\n"}
```