### PR TITLE
Add /var/log/warn to logrotate

### DIFF
--- a/tasks/section_4_Logging_and_Auditing.yaml
+++ b/tasks/section_4_Logging_and_Auditing.yaml
@@ -552,10 +552,27 @@
 # archive these files to another system and spend less time looking through inordinately
 # large log files.
 - name: 4.3 Ensure logrotate is configured
-  replace:
-    path: /etc/logrotate.d/rsyslog
-    regexp: '^(\s*)(daily|weekly|monthly|yearly)$'
-    replace: "\\1{{ logrotate_policy }}"
+  block:
+    - name: 4.3 Ensure logrotate is configured - set logrotate policy
+      replace:
+        path: /etc/logrotate.d/rsyslog
+        regexp: '^(\s*)(daily|weekly|monthly|yearly)$'
+        replace: "\\1{{ logrotate_policy }}"
+    - name: 4.3 Ensure logrotate is configured - check for /var/log/warn
+      shell: |
+        grep '^/var/log/warn$' /etc/logrotate.d/rsyslog && true || true
+      register: output_4_3
+      changed_when: output_4_3.stdout | trim | length == 0
+      check_mode: no
+    - name: 4.3 Ensure logrotate is configured - print output
+      debug:
+        msg: "{{ output_4_3.stdout_lines }}"
+    - name: 4.3 Ensure logrotate is configured - add /var/log/warn
+      replace:
+        path: /etc/logrotate.d/rsyslog
+        regexp: '^{$'
+        replace: "/var/log/warn\n{"
+      when: output_4_3.stdout | trim | length == 0
   tags:
     - section4
     - level_1_server


### PR DESCRIPTION
The log file `/var/log/warn` is created after executing `4.2.1.3` since https://github.com/dbernaci/CIS-Debian10-Ansible/blob/main/templates/rsyslog.conf.j2 contains the following:

```
*.=warning;*.=err	-/var/log/warn
*.crit				/var/log/warn
```

But, once the log file is created, it is never rotated.

This PR adds `/var/log/warn` to logrotate in `4.3`.