### PR TITLE
Add "list" to end of "with_items" filter for 1.1.3, 1.1.8, and 1.1.14

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -209,7 +209,7 @@
         fstype: "{{ item.fstype }}"
         opts: defaults,nodev,nosuid,noexec
         state: present
-      with_items: "{{ ansible_mounts | byattr('mount', '/tmp') }}"
+      with_items: "{{ ansible_mounts | byattr('mount', '/tmp') | list }}"
   tags:
     - section1
     - level_1_server
@@ -264,7 +264,7 @@
         fstype: "{{ item.fstype }}"
         opts: defaults,nodev,nosuid,noexec
         state: present
-      with_items: "{{ ansible_mounts | byattr('mount', '/var/tmp') }}"
+      with_items: "{{ ansible_mounts | byattr('mount', '/var/tmp') | list }}"
   tags:
     - section1
     - level_1_server
@@ -329,7 +329,7 @@
         fstype: "{{ item.fstype }}"
         opts: defaults,nodev
         state: present
-      with_items: " {{ ansible_mounts | byattr('mount', '/home') }}"
+      with_items: " {{ ansible_mounts | byattr('mount', '/home') | list }}"
   tags:
     - section1
     - level_2_server


### PR DESCRIPTION
Similar to the PR https://github.com/dbernaci/CIS-Debian10-Ansible/pull/9, the following error was not received when running the Ansible Playbook locally on a host but when running remotely would receive the following:

```
TASK [CIS-Debian10-Ansible : 1.1.3 Ensure nodev option set on /tmp partition, 1.1.4 Ensure nosuid option set on /tmp partition, 1.1.5 Ensure noexec option set on /tmp partition] ***
fatal: [a.b.c.d]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'device'\n\nThe error appears to be in '/path/CIS-Debian10-Ansible/tasks/section_1_Initial_Setup.yaml': line 203, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n        success_msg: \"/tmp is a separate partition\"\n    - name: 1.1.3 Ensure nodev option set on /tmp partition,\n      ^ here\n"}
```