### PR TITLE
Update to make missing dir in 6.2.8 non-fatal

### DIFF
--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -451,7 +451,7 @@
         name: "{{ item }}"
         mode: "g-w,o-rwx"
       with_items: "{{ output_6_2_8.stdout | regex_search('^\/.*', multiline=True) | trim }}"
-      when: output_6_2_8.stdout | trim | length > 0
+      when: (output_6_2_8.stdout | regex_search('^\/.*', multiline=True) | trim != 'None' and output_6_2_8.stdout | trim | length > 0)
   tags:
     - section6
     - level_1_server

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -451,7 +451,7 @@
         name: "{{ item }}"
         mode: "g-w,o-rwx"
       with_items: "{{ output_6_2_8.stdout | regex_search('^\/.*', multiline=True) | trim }}"
-      when: output_6_2_8.stdout | regex_search('^\/.*', multiline=True) | trim | length > 0
+      when: output_6_2_8.stdout | trim | length > 0
   tags:
     - section6
     - level_1_server

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -439,15 +439,19 @@
       changed_when: output_6_2_8.stdout | trim | length > 0
       register: output_6_2_8
       check_mode: no
-    - name: 6.2.8 Ensure users' home directories permissions are 750 or more restrictive - print output
+    - name: 6.2.8 Ensure users' home directories permissions are 750 or more restrictive - print missing dirs
       debug:
-        msg: "{{ output_6_2_8.stdout_lines | select() | list }}"
+        msg: "{{ output_6_2_8.stdout | regex_search('.*does not exist.*', multiline=True) | trim }}"
+      when: output_6_2_8.stdout | regex_search('.*does not exist.*', multiline=True) | trim | length > 0
+    - name: 6.2.8 Ensure users' home directories permissions are 750 or more restrictive - print dirs to chmod
+      debug:
+        msg: "{{ output_6_2_8.stdout | regex_search('^\/.*', multiline=True) | trim }}"
     - name: 6.2.8 Ensure users home directories permissions are 750 or more restrictive - fix
       file:
         name: "{{ item }}"
         mode: "g-w,o-rwx"
-      with_items: "{{ output_6_2_8.stdout_lines | select() | list }}"
-      when: output_6_2_8.stdout | trim | length > 0
+      with_items: "{{ output_6_2_8.stdout | regex_search('^\/.*', multiline=True) | trim }}"
+      when: output_6_2_8.stdout | regex_search('^\/.*', multiline=True) | trim | length > 0
   tags:
     - section6
     - level_1_server


### PR DESCRIPTION
This PR updates 6.2.8 so that if an entry exists in `/etc/passwd` but a homedir doesn't exist on the server, then it will be printed out in a debug but a chmod will not be attempted (which was causing the fatal error previously).

This will also help when a user in `/etc/passwd` is using a `nologin` with a path that is different than the output of `which nologin`. For example, if `which nologin` returns `/usr/sbin/nologin`, then a fatal error will not occur if a user is instead configured with `/sbin/nologin`.