### PR TITLE
Use Ansible file module to set sticky bit

### DIFF
--- a/files/1_1_21.sh
+++ b/files/1_1_21.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null | xargs -I '{}' chmod a+t '{}'

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -493,7 +493,10 @@
       changed_when: output_1_1_21.stdout_lines | length > 0
       check_mode: no
     - name: 1.1.21 Ensure sticky bit is set on all world-writable directories - fix
-      script: 1_1_21.sh
+      file:
+        path: "{{ item }}"
+        mode: 'a+t'
+      loop: "{{ output_1_1_21.stdout_lines }}"
       when: output_1_1_21.stdout_lines | length > 0
   tags:
     - section1

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -490,7 +490,7 @@
       shell: |
         df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null
       register: output_1_1_21
-      changed_when: output_1_1_21.stdout_lines | length > 0
+      changed_when: false  # read-only task
       check_mode: no
     - name: 1.1.21 Ensure sticky bit is set on all world-writable directories - fix
       file:


### PR DESCRIPTION
Gives a proper diff output to precisely see which directory gets modified.
Also makes the operation atomic because world writable
directories might get modified between the `get info` and the `fix` task.